### PR TITLE
epi_slide `f` parameter documentation

### DIFF
--- a/R/slide.R
+++ b/R/slide.R
@@ -84,7 +84,27 @@
 #'   tidy evaluation (first example, above), then the name for the new column is 
 #'   inferred from the given expression and overrides any name passed explicitly 
 #'   through the `new_col_name` argument.
-#' 
+#'   
+#' If a tibble that does not have a designated grouping variable is passed in 
+#'   as the method argument to `f`, to prevent the specified method for `f` 
+#'   from being overridden, include a parameter for the grouping-variable in 
+#'   function() just prior to specifying the method. For example:
+#'   ```
+#'   # Construct an tibble with an unnamed grouping-variable
+#'   edf = bind_rows(tibble(geo_value = "ak", time_value = as.Date("2020-01-01") 
+#'             + 1:10, x1=1:10, y=1:10 + rnorm(10L))) %>% 
+#'     as_epi_df()
+#'   
+#'   # Now, include a row parameter for the grouping-variable in the tibble, 
+#'   # which we denote as g, just prior to method = "qr"
+#'   # Note that if g was not included below, then the method = "qr" would be 
+#'   # overridden, as described above
+#'   edf %>%
+#'   group_by(geo_value) %>%
+#'   epi_slide(function(x, g, method="qr", ...) tibble(model=list(
+#'             lm(y ~ x1, x, method=method))), n=7L) 
+#'   ```
+#'   
 #' @importFrom lubridate days weeks
 #' @importFrom rlang .data .env !! enquo enquos sym
 #' @export

--- a/R/slide.R
+++ b/R/slide.R
@@ -85,11 +85,11 @@
 #'   inferred from the given expression and overrides any name passed explicitly 
 #'   through the `new_col_name` argument.
 #'   
-#' When `f` is a named function with arguments, if a tibble that does not have a 
-#'   designated grouping variable is passed in as the method argument to `f`, 
-#'   to prevent the specified method for `f` from being overridden, include a 
-#'   parameter for the grouping-variable in function() just prior to specifying 
-#'   the method. For example:
+#' If `f` is a named function with arguments and a tibble with an unnamed
+#'   grouping variable is passed in as its method argument, then naturally
+#'   any specified method for `f` would be overridden. To prevent this, include 
+#'   a parameter for the grouping variable in `function()` just prior to  
+#'   specifying the method. For example:
 #'   ```
 #'   # Construct an tibble with an unnamed grouping variable
 #'   edf = bind_rows(tibble(geo_value = "ak", time_value = as.Date("2020-01-01") 

--- a/R/slide.R
+++ b/R/slide.R
@@ -85,11 +85,10 @@
 #'   inferred from the given expression and overrides any name passed explicitly 
 #'   through the `new_col_name` argument.
 #'   
-#' If `f` is a named function with arguments and a tibble with an unnamed
-#'   grouping variable is passed in as its method argument, then naturally
-#'   any specified method for `f` would be overridden. To prevent this, include 
-#'   a parameter for the grouping variable in `function()` just prior to  
-#'   specifying the method. For example:
+#' When `f` is a named function with arguments, if a tibble with an unnamed 
+#'   grouping variable is passed in as the method argument to `f`, include a 
+#'   parameter for the grouping-variable in `function()` just prior to 
+#'   specifying the method to prevent that from being overridden. For example:
 #'   ```
 #'   # Construct an tibble with an unnamed grouping variable
 #'   edf = bind_rows(tibble(geo_value = "ak", time_value = as.Date("2020-01-01") 

--- a/R/slide.R
+++ b/R/slide.R
@@ -85,17 +85,18 @@
 #'   inferred from the given expression and overrides any name passed explicitly 
 #'   through the `new_col_name` argument.
 #'   
-#' If a tibble that does not have a designated grouping variable is passed in 
-#'   as the method argument to `f`, to prevent the specified method for `f` 
-#'   from being overridden, include a parameter for the grouping-variable in 
-#'   function() just prior to specifying the method. For example:
+#' When `f` is a named function with arguments, if a tibble that does not have a 
+#'   designated grouping variable is passed in as the method argument to `f`, 
+#'   to prevent the specified method for `f` from being overridden, include a 
+#'   parameter for the grouping-variable in function() just prior to specifying 
+#'   the method. For example:
 #'   ```
-#'   # Construct an tibble with an unnamed grouping-variable
+#'   # Construct an tibble with an unnamed grouping variable
 #'   edf = bind_rows(tibble(geo_value = "ak", time_value = as.Date("2020-01-01") 
 #'             + 1:10, x1=1:10, y=1:10 + rnorm(10L))) %>% 
 #'     as_epi_df()
 #'   
-#'   # Now, include a row parameter for the grouping-variable in the tibble, 
+#'   # Now, include a row parameter for the grouping variable in the tibble, 
 #'   # which we denote as g, just prior to method = "qr"
 #'   # Note that if g was not included below, then the method = "qr" would be 
 #'   # overridden, as described above

--- a/man/epi_slide.Rd
+++ b/man/epi_slide.Rd
@@ -115,6 +115,24 @@ Thus, to be clear, when the computation is specified via an expression for
 tidy evaluation (first example, above), then the name for the new column is
 inferred from the given expression and overrides any name passed explicitly
 through the \code{new_col_name} argument.
+
+When \code{f} is a named function with arguments, if a tibble with an unnamed
+grouping variable is passed in as the method argument to \code{f}, include a
+parameter for the grouping-variable in \verb{function()} just prior to
+specifying the method to prevent that from being overridden. For example:\preformatted{# Construct an tibble with an unnamed grouping variable
+edf = bind_rows(tibble(geo_value = "ak", time_value = as.Date("2020-01-01") 
+          + 1:10, x1=1:10, y=1:10 + rnorm(10L))) \%>\% 
+  as_epi_df()
+
+# Now, include a row parameter for the grouping variable in the tibble, 
+# which we denote as g, just prior to method = "qr"
+# Note that if g was not included below, then the method = "qr" would be 
+# overridden, as described above
+edf \%>\%
+group_by(geo_value) \%>\%
+epi_slide(function(x, g, method="qr", ...) tibble(model=list(
+          lm(y ~ x1, x, method=method))), n=7L) 
+}
 }
 \examples{
  # slide a 7-day trailing average formula on cases


### PR DESCRIPTION
Revised the `epi_slide` function documentation (lines 88 - 106) to briefly describe the problem arising when a tibble with an unnamed grouping variable is passed to the method arg. of `f` and the first solution from [Issue #66](https://github.com/cmu-delphi/epiprocess/issues/66).